### PR TITLE
disk: Default to direct-io=off in losetup wrapper

### DIFF
--- a/pkg/bootc/bootc_disk.go
+++ b/pkg/bootc/bootc_disk.go
@@ -44,7 +44,7 @@ for arg in "$@"; do
 		*) args+="$arg" ;;
 	esac
 done
-exec /usr/sbin/losetup "$@"
+exec /usr/sbin/losetup "$@" --direct-io=off
 `
 
 // DiskImageConfig defines configuration for the


### PR DESCRIPTION
losetup defaults to on when the arg is not present

I mistakenly tested the original wrapper changes with my patched image that included the bootc fix. Verified this works on my machine.