### PR TITLE
run: Add support for disk and rootfs controls

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,6 +56,8 @@ func init() {
 	runCmd.Flags().BoolVarP(&vmConfig.Background, "background", "B", false, "Do not spawn SSH, run in background")
 	runCmd.Flags().BoolVar(&vmConfig.RemoveVm, "rm", false, "Remove the VM and it's disk when the SSH session exits. Cannot be used with --background")
 	runCmd.Flags().BoolVar(&vmConfig.Quiet, "quiet", false, "Suppress output from bootc disk creation and VM boot console")
+	runCmd.Flags().StringVar(&diskImageConfigInstance.RootSizeMax, "root-size-max", "", "Maximum size of root filesystem in bytes; optionally accepts M, G, T suffixes")
+	runCmd.Flags().StringVar(&diskImageConfigInstance.DiskSize, "disk-size", "", "Allocate a disk image of this size in bytes; optionally accepts M, G, T suffixes")
 }
 
 func doRun(flags *cobra.Command, args []string) error {


### PR DESCRIPTION
The goal is to be able to trivially replicate locally a "cloud-like" scenario where:

- The rootfs is capped to some default size at disk image generation time
- The infrastructure provides a larger block device at boot time