### PR TITLE
ssh: Don't add an entry to known_hosts

### DIFF
--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -232,7 +232,9 @@ func (v *BootcVMCommon) RunSSH(inputArgs []string) error {
 		"-o", "IdentitiesOnly=yes",
 		"-o", "PasswordAuthentication=no",
 		"-o", "StrictHostKeyChecking=no",
-		"-o", "LogLevel=ERROR", "-o", "SetEnv=LC_ALL="}
+		"-o", "LogLevel=ERROR",
+		"-o", "SetEnv=LC_ALL=",
+		"-o", "UserKnownHostsFile=/dev/null"}
 	if len(inputArgs) > 0 {
 		args = append(args, inputArgs...)
 	} else {


### PR DESCRIPTION
When running podman-bootc multiple times the known_hosts file quickly becomes cluttered with podman-bootc entries.