### PR TITLE
Restrict VM test only on linux

### DIFF
--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package vm_test
 
 import (


### PR DESCRIPTION
These tests are only testing linux VMs, so let's make sure this files only compiles on linux, so it will not interfere with future mac tests.