### PR TITLE
disk: Recreate the bootc disk image when passed certain parameters

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -136,8 +136,16 @@ func doRun(flags *cobra.Command, args []string) error {
 		return fmt.Errorf("VM already running, use the ssh command to connect to it")
 	}
 
+	// if any of these parameters are set, we need to rebuild the disk image if one exists
+	bustCache := false
+	if diskImageConfigInstance.DiskSize != "" ||
+		diskImageConfigInstance.RootSizeMax != "" ||
+		diskImageConfigInstance.Filesystem != "" {
+		bustCache = true
+	}
+
 	// create the disk image
-	bootcDisk := bootc.NewBootcDisk(containerImage, ctx, user, cache)
+	bootcDisk := bootc.NewBootcDisk(containerImage, ctx, user, cache, bustCache)
 	err = bootcDisk.Install(vmConfig.Quiet, diskImageConfigInstance)
 
 	if err != nil {

--- a/pkg/bootc/bootc_disk.go
+++ b/pkg/bootc/bootc_disk.go
@@ -13,12 +13,11 @@ import (
 	"syscall"
 	"time"
 
-	"gitlab.com/bootc-org/podman-bootc/pkg/config"
+	"gitlab.com/bootc-org/podman-bootc/pkg/cache"
+	"gitlab.com/bootc-org/podman-bootc/pkg/container"
 	"gitlab.com/bootc-org/podman-bootc/pkg/user"
-	"gitlab.com/bootc-org/podman-bootc/pkg/utils"
 
 	"github.com/containers/podman/v5/pkg/bindings/containers"
-	"github.com/containers/podman/v5/pkg/bindings/images"
 	"github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/docker/go-units"
@@ -62,14 +61,11 @@ type diskFromContainerMeta struct {
 }
 
 type BootcDisk struct {
-	ImageNameOrId           string
+	ContainerImage          container.ContainerImage
+	Cache                   cache.Cache
 	User                    user.User
 	Ctx                     context.Context
-	ImageId                 string
-	imageData               *types.ImageInspectReport
-	RepoTag                 string
 	CreatedAt               time.Time
-	Directory               string
 	file                    *os.File
 	bootcInstallContainerId string
 }
@@ -80,38 +76,32 @@ var (
 	instanceOnce sync.Once
 )
 
-func NewBootcDisk(imageNameOrId string, ctx context.Context, user user.User) *BootcDisk {
+// NewBootcDisk creates a new BootcDisk instance
+//
+// Parameters:
+//   - imageNameOrId: the name or id of the container image
+//   - ctx: context for the podman machine connection
+//   - user: the user who is running the command, determines where the disk image is stored
+func NewBootcDisk(containerImage container.ContainerImage, ctx context.Context, user user.User, cache cache.Cache) *BootcDisk {
 	instanceOnce.Do(func() {
 		instance = &BootcDisk{
-			ImageNameOrId: imageNameOrId,
-			Ctx:           ctx,
-			User:          user,
+			ContainerImage: containerImage,
+			Ctx:            ctx,
+			User:           user,
+			Cache:          cache,
 		}
 	})
 	return instance
 }
 
-func (p *BootcDisk) GetDirectory() string {
-	return p.Directory
-}
-
-func (p *BootcDisk) GetImageId() string {
-	return p.ImageId
-}
-
 // GetSize returns the virtual size of the disk in bytes;
 // this may be larger than the actual disk usage
 func (p *BootcDisk) GetSize() (int64, error) {
-	st, err := os.Stat(filepath.Join(p.Directory, config.DiskImage))
+	st, err := os.Stat(p.Cache.GetDiskPath())
 	if err != nil {
 		return 0, err
 	}
 	return st.Size(), nil
-}
-
-// GetRepoTag returns the repository of the container image
-func (p *BootcDisk) GetRepoTag() string {
-	return p.RepoTag
 }
 
 // GetCreatedAt returns the creation time of the disk image
@@ -121,32 +111,6 @@ func (p *BootcDisk) GetCreatedAt() time.Time {
 
 func (p *BootcDisk) Install(quiet bool, config DiskImageConfig) (err error) {
 	p.CreatedAt = time.Now()
-
-	err = p.pullImage()
-	if err != nil {
-		return
-	}
-
-	// Create VM cache dir; one per oci bootc image
-	p.Directory = filepath.Join(p.User.CacheDir(), p.ImageId)
-	lock := utils.NewCacheLock(p.User.RunDir(), p.Directory)
-	locked, err := lock.TryLock(utils.Exclusive)
-	if err != nil {
-		return fmt.Errorf("error locking the VM cache path: %w", err)
-	}
-	if !locked {
-		return fmt.Errorf("unable to lock the VM cache path")
-	}
-
-	defer func() {
-		if err := lock.Unlock(); err != nil {
-			logrus.Errorf("unable to unlock VM %s: %v", p.ImageId, err)
-		}
-	}()
-
-	if err := os.MkdirAll(p.Directory, os.ModePerm); err != nil {
-		return fmt.Errorf("error while making bootc disk directory: %w", err)
-	}
 
 	err = p.getOrInstallImageToDisk(quiet, config)
 	if err != nil {
@@ -173,7 +137,7 @@ func (p *BootcDisk) Cleanup() (err error) {
 
 // getOrInstallImageToDisk checks if the disk is present and if not, installs the image to a new disk
 func (p *BootcDisk) getOrInstallImageToDisk(quiet bool, diskConfig DiskImageConfig) error {
-	diskPath := filepath.Join(p.Directory, config.DiskImage)
+	diskPath := p.Cache.GetDiskPath()
 	f, err := os.Open(diskPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -199,8 +163,8 @@ func (p *BootcDisk) getOrInstallImageToDisk(quiet bool, diskConfig DiskImageConf
 		return p.bootcInstallImageToDisk(quiet, diskConfig)
 	}
 
-	logrus.Debugf("previous disk digest: %s current digest: %s", serializedMeta.ImageDigest, p.ImageId)
-	if serializedMeta.ImageDigest == p.ImageId {
+	logrus.Debugf("previous disk digest: %s current digest: %s", serializedMeta.ImageDigest, p.ContainerImage.GetId())
+	if serializedMeta.ImageDigest == p.ContainerImage.GetId() {
 		return nil
 	}
 
@@ -217,12 +181,12 @@ func align(size int64, align int64) int64 {
 
 // bootcInstallImageToDisk creates a disk image from a bootc container
 func (p *BootcDisk) bootcInstallImageToDisk(quiet bool, diskConfig DiskImageConfig) (err error) {
-	fmt.Printf("Executing `bootc install to-disk` from container image %s to create disk image\n", p.RepoTag)
-	p.file, err = os.CreateTemp(p.Directory, "podman-bootc-tempdisk")
+	fmt.Printf("Executing `bootc install to-disk` from container image %s to create disk image\n", p.ContainerImage.GetRepoTag())
+	p.file, err = os.CreateTemp(p.Cache.GetDirectory(), "podman-bootc-tempdisk")
 	if err != nil {
 		return err
 	}
-	size := p.imageData.Size * containerSizeToDiskSizeMultiplier
+	size := p.ContainerImage.GetSize() * containerSizeToDiskSizeMultiplier
 	if size < diskSizeMinimum {
 		size = diskSizeMinimum
 	}
@@ -237,7 +201,7 @@ func (p *BootcDisk) bootcInstallImageToDisk(quiet bool, diskConfig DiskImageConf
 	}
 	// Round up to 4k; loopback wants at least 512b alignment
 	size = align(size, 4096)
-	humanContainerSize := units.HumanSize(float64(p.imageData.Size))
+	humanContainerSize := units.HumanSize(float64(p.ContainerImage.GetSize()))
 	humanSize := units.HumanSize(float64(size))
 	logrus.Infof("container size: %s, disk size: %s", humanContainerSize, humanSize)
 
@@ -257,7 +221,7 @@ func (p *BootcDisk) bootcInstallImageToDisk(quiet bool, diskConfig DiskImageConf
 		return fmt.Errorf("failed to create disk image: %w", err)
 	}
 	serializedMeta := diskFromContainerMeta{
-		ImageDigest: p.ImageId,
+		ImageDigest: p.ContainerImage.GetId(),
 	}
 	buf, err := json.Marshal(serializedMeta)
 	if err != nil {
@@ -266,8 +230,8 @@ func (p *BootcDisk) bootcInstallImageToDisk(quiet bool, diskConfig DiskImageConf
 	if err := unix.Fsetxattr(int(p.file.Fd()), imageMetaXattr, buf, 0); err != nil {
 		return fmt.Errorf("failed to set xattr: %w", err)
 	}
-	diskPath := filepath.Join(p.Directory, config.DiskImage)
 
+	diskPath := p.Cache.GetDiskPath()
 	if err := os.Rename(p.file.Name(), diskPath); err != nil {
 		return fmt.Errorf("failed to rename to %s: %w", diskPath, err)
 	}
@@ -276,39 +240,10 @@ func (p *BootcDisk) bootcInstallImageToDisk(quiet bool, diskConfig DiskImageConf
 	return nil
 }
 
-// pullImage fetches the container image if not present
-func (p *BootcDisk) pullImage() (err error) {
-	pullPolicy := "missing"
-	ids, err := images.Pull(p.Ctx, p.ImageNameOrId, &images.PullOptions{Policy: &pullPolicy})
-	if err != nil {
-		return fmt.Errorf("failed to pull image: %w", err)
-	}
-
-	if len(ids) == 0 {
-		return fmt.Errorf("no ids returned from image pull")
-	}
-
-	if len(ids) > 1 {
-		return fmt.Errorf("multiple ids returned from image pull")
-	}
-
-	image, err := images.GetImage(p.Ctx, p.ImageNameOrId, &images.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get image: %w", err)
-	}
-	p.imageData = image
-
-	imageId := ids[0]
-	p.ImageId = imageId
-	p.RepoTag = image.RepoTags[0]
-
-	return
-}
-
 // runInstallContainer runs the bootc installer in a container to create a disk image
 func (p *BootcDisk) runInstallContainer(quiet bool, config DiskImageConfig) (err error) {
 	// Create a temporary external shell script with the contents of our losetup wrapper
-	losetupTemp, err := os.CreateTemp(p.Directory, "losetup-wrapper")
+	losetupTemp, err := os.CreateTemp(p.Cache.GetDirectory(), "losetup-wrapper")
 	if err != nil {
 		return fmt.Errorf("temp losetup wrapper: %w", err)
 	}
@@ -433,7 +368,7 @@ func (p *BootcDisk) createInstallContainer(config DiskImageConfig, tempLosetup s
 			Env:         targetEnv,
 		},
 		ContainerStorageConfig: specgen.ContainerStorageConfig{
-			Image: p.ImageNameOrId,
+			Image: p.ContainerImage.ImageNameOrId,
 			Mounts: []specs.Mount{
 				{
 					Source:      "/var/lib/containers",
@@ -446,7 +381,7 @@ func (p *BootcDisk) createInstallContainer(config DiskImageConfig, tempLosetup s
 					Type:        "bind",
 				},
 				{
-					Source:      p.Directory,
+					Source:      p.Cache.GetDirectory(),
 					Destination: "/output",
 					Type:        "bind",
 				},

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"gitlab.com/bootc-org/podman-bootc/pkg/user"
+	"gitlab.com/bootc-org/podman-bootc/pkg/utils"
+)
+
+func NewCache(imageId string, user user.User) Cache {
+	return Cache{
+		ImageId: imageId,
+		User:    user,
+	}
+}
+
+type Cache struct {
+	User      user.User
+	ImageId   string
+	Directory string
+	Created	  bool
+}
+
+// Create VM cache dir; one per oci bootc image
+func (p *Cache) Create() (err error) {
+	p.Directory = filepath.Join(p.User.CacheDir(), p.ImageId)
+	lock := utils.NewCacheLock(p.User.RunDir(), p.Directory)
+	locked, err := lock.TryLock(utils.Exclusive)
+	if err != nil {
+		return fmt.Errorf("error locking the VM cache path: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("unable to lock the VM cache path")
+	}
+
+	defer func() {
+		if err := lock.Unlock(); err != nil {
+			logrus.Errorf("unable to unlock VM %s: %v", p.ImageId, err)
+		}
+	}()
+
+	if err := os.MkdirAll(p.Directory, os.ModePerm); err != nil {
+		return fmt.Errorf("error while making bootc disk directory: %w", err)
+	}
+
+	p.Created = true
+
+	return
+}
+
+func (p *Cache) GetDirectory() string {
+	if !p.Created {
+		panic("cache not created")
+	}
+	return p.Directory
+}
+
+func (p *Cache) GetDiskPath() string {
+	if !p.Created {
+		panic("cache not created")
+	}
+	return filepath.Join(p.GetDirectory(), "disk.raw")
+}

--- a/pkg/container/image.go
+++ b/pkg/container/image.go
@@ -1,0 +1,76 @@
+package container
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containers/podman/v5/pkg/bindings/images"
+)
+
+func NewContainerImage(imageNameOrId string, ctx context.Context) ContainerImage {
+	return ContainerImage{
+		ImageNameOrId: imageNameOrId,
+		Ctx:           ctx,
+	}
+}
+
+type ContainerImage struct {
+	ImageNameOrId string
+	Ctx           context.Context
+	Id            string
+	RepoTag       string
+	Size          int64
+	Pulled        bool
+}
+
+// pullImage fetches the container image if not present
+func (p *ContainerImage) Pull() (err error) {
+	pullPolicy := "missing"
+	ids, err := images.Pull(p.Ctx, p.ImageNameOrId, &images.PullOptions{Policy: &pullPolicy})
+	if err != nil {
+		return fmt.Errorf("failed to pull image: %w", err)
+	}
+
+	if len(ids) == 0 {
+		return fmt.Errorf("no ids returned from image pull")
+	}
+
+	if len(ids) > 1 {
+		return fmt.Errorf("multiple ids returned from image pull")
+	}
+
+	image, err := images.GetImage(p.Ctx, p.ImageNameOrId, &images.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get image: %w", err)
+	}
+	p.Size = image.Size
+	p.Id = ids[0]
+	p.RepoTag = image.RepoTags[0]
+	p.Pulled = true
+
+	return
+}
+
+func (p *ContainerImage) GetId() string {
+	if !p.Pulled {
+		panic("image not pulled")
+	}
+
+	return p.Id
+}
+
+func (p *ContainerImage) GetRepoTag() string {
+	if !p.Pulled {
+		panic("image not pulled")
+	}
+
+	return p.RepoTag
+}
+
+func (p *ContainerImage) GetSize() int64 {
+	if !p.Pulled {
+		panic("image not pulled")
+	}
+
+	return p.Size
+}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14,6 +14,7 @@ import (
 
 	"gitlab.com/bootc-org/podman-bootc/pkg/bootc"
 	"gitlab.com/bootc-org/podman-bootc/pkg/config"
+	"gitlab.com/bootc-org/podman-bootc/pkg/container"
 	"gitlab.com/bootc-org/podman-bootc/pkg/user"
 	"gitlab.com/bootc-org/podman-bootc/pkg/utils"
 
@@ -68,7 +69,7 @@ type BootcVM interface {
 	Run(RunVMParameters) error
 	Delete() error
 	IsRunning() (bool, error)
-	WriteConfig(bootc.BootcDisk) error
+	WriteConfig(bootc.BootcDisk, container.ContainerImage) error
 	WaitForSSHToBeReady() error
 	RunSSH([]string) error
 	DeleteFromCache() error
@@ -112,7 +113,7 @@ type BootcVMConfig struct {
 }
 
 // writeConfig writes the configuration for the VM to the disk
-func (v *BootcVMCommon) WriteConfig(bootcDisk bootc.BootcDisk) error {
+func (v *BootcVMCommon) WriteConfig(bootcDisk bootc.BootcDisk, containerImage container.ContainerImage) error {
 	size, err := bootcDisk.GetSize()
 	if err != nil {
 		return fmt.Errorf("get disk size: %w", err)
@@ -121,7 +122,7 @@ func (v *BootcVMCommon) WriteConfig(bootcDisk bootc.BootcDisk) error {
 		Id:          v.imageID[0:12],
 		SshPort:     v.sshPort,
 		SshIdentity: v.sshIdentity,
-		RepoTag:     bootcDisk.GetRepoTag(),
+		RepoTag:     containerImage.GetRepoTag(),
 		Created:     bootcDisk.GetCreatedAt().Format(time.RFC3339),
 		DiskSize:    strconv.FormatInt(size, 10),
 	}

--- a/podman-bootc.go
+++ b/podman-bootc.go
@@ -59,7 +59,7 @@ func cleanup() {
 	}
 
 	//delete the disk image
-	err = bootc.NewBootcDisk(container.ContainerImage{}, ctx, user, cache.Cache{}).Cleanup()
+	err = bootc.NewBootcDisk(container.ContainerImage{}, ctx, user, cache.Cache{}, false).Cleanup()
 	if err != nil {
 		logrus.Errorf("unable to get podman machine info: %s", err)
 		os.Exit(0)

--- a/podman-bootc.go
+++ b/podman-bootc.go
@@ -9,6 +9,8 @@ import (
 
 	"gitlab.com/bootc-org/podman-bootc/cmd"
 	"gitlab.com/bootc-org/podman-bootc/pkg/bootc"
+	"gitlab.com/bootc-org/podman-bootc/pkg/cache"
+	"gitlab.com/bootc-org/podman-bootc/pkg/container"
 	"gitlab.com/bootc-org/podman-bootc/pkg/user"
 	"gitlab.com/bootc-org/podman-bootc/pkg/utils"
 
@@ -57,7 +59,7 @@ func cleanup() {
 	}
 
 	//delete the disk image
-	err = bootc.NewBootcDisk("", ctx, user).Cleanup()
+	err = bootc.NewBootcDisk(container.ContainerImage{}, ctx, user, cache.Cache{}).Cleanup()
 	if err != nil {
 		logrus.Errorf("unable to get podman machine info: %s", err)
 		os.Exit(0)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -307,4 +307,62 @@ var _ = Describe("E2E", func() {
 			e2e.Cleanup()
 		})
 	})
+
+
+	Context("Modifying disk size", Ordered, func() {
+		var vm *e2e.TestVM
+
+		BeforeAll(func() {
+			var err error
+			vm, err = e2e.BootVM(e2e.BaseImage, "--disk-size", "25G")
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		It("Should create a new VM with a specific disk size", func() {
+			vmDirs, err := e2e.ListCacheDirs()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(vmDirs).To(HaveLen(1))
+
+			fileInfo, err := os.Stat(filepath.Join(vmDirs[0], config.DiskImage))
+			Expect(err).To(Not(HaveOccurred()))
+
+			Expect(fileInfo.Size()).To(Equal(int64(25000001536)))
+		})
+
+		It("Should fail to resize a VM's disk size while the VM is running", func() {
+			_, _, err := e2e.RunPodmanBootc("run", e2e.BaseImage, "--disk-size", "26G")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should resize an existing VM's disk size", func() {
+			//stop the VM first
+			err := vm.StdIn.Close()
+			Expect(err).To(Not(HaveOccurred()))
+			_, _, err = e2e.RunPodmanBootc("stop", vm.Id)
+			Expect(err).To(Not(HaveOccurred()))
+
+			Eventually(func() bool {
+				vmExists, err := e2e.VMExists(vm.Id)
+				Expect(err).To(Not(HaveOccurred()))
+				return vmExists
+			}).Should(BeFalse())
+
+			//resize the disk
+			vm, err = e2e.BootVM(e2e.BaseImage, "--disk-size", "27G")
+			Expect(err).To(Not(HaveOccurred()))
+
+			//verify the disk size
+			vmDirs, err := e2e.ListCacheDirs()
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(vmDirs).To(HaveLen(1))
+			fileInfo, err := os.Stat(filepath.Join(vmDirs[0], config.DiskImage))
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(fileInfo.Size()).To(Equal(int64(27000000512)))
+		})
+
+		AfterAll(func() {
+			vm.StdIn.Close()
+			e2e.Cleanup()
+		})
+	})
 })

--- a/test/e2e/e2e_utils.go
+++ b/test/e2e/e2e_utils.go
@@ -105,8 +105,10 @@ func GetVMIdFromContainerImage(image string) (vmId string, err error) {
 	return
 }
 
-func BootVM(image string) (vm *TestVM, err error) {
-	runActiveCmd := exec.Command(PodmanBootcBinary(), "run", image)
+func BootVM(image string, args ...string) (vm *TestVM, err error) {
+	cmd := []string{"run", image}
+	cmd = append(cmd, args...)
+	runActiveCmd := exec.Command(PodmanBootcBinary(), cmd...)
 	stdIn, err := runActiveCmd.StdinPipe()
 
 	if err != nil {


### PR DESCRIPTION
Sometimes the disk image needs to be recreated even if reusing
the same container image, for example when passing --disk-size
to create a bootc disk with a larger disk size.

-----------------

disk: Refactor image pull and cache dir creation

This creates two new structs, image and cache, and removes the code to
pull the image and create the cache directory from bootc_disk. This is
done in order to check if the VM is running before creating the disk to
fail early. We need the pulled container image ID before checking
if the VM is running.

This also gets us closer to separately managing the cache dir which should
simplify some of the lock code.

This is in preparation for the code to clear the cached
disk image when modifying the disk image size or filesystem type. Prior
to these changes, the disk could be recreated before checking if the VM
is running.

