### PR TITLE
run: Add support for --bind (on linux, with virtiofsd)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,6 +28,7 @@ type osVmConfig struct {
 	RemoveVm        bool // Kill the running VM when it exits
 	RemoveDiskImage bool // After exit of the VM, remove the disk image
 	Quiet           bool
+	BindMounts      []string
 }
 
 var (
@@ -58,6 +59,7 @@ func init() {
 	runCmd.Flags().BoolVar(&vmConfig.Quiet, "quiet", false, "Suppress output from bootc disk creation and VM boot console")
 	runCmd.Flags().StringVar(&diskImageConfigInstance.RootSizeMax, "root-size-max", "", "Maximum size of root filesystem in bytes; optionally accepts M, G, T suffixes")
 	runCmd.Flags().StringVar(&diskImageConfigInstance.DiskSize, "disk-size", "", "Allocate a disk image of this size in bytes; optionally accepts M, G, T suffixes")
+	runCmd.Flags().StringArrayVar(&vmConfig.BindMounts, "bind", nil, "Create a virtiofs mount between host and guest, separated by a `:`")
 }
 
 func doRun(flags *cobra.Command, args []string) error {
@@ -141,6 +143,7 @@ func doRun(flags *cobra.Command, args []string) error {
 		CloudInitDir:  vmConfig.CloudInitDir,
 		NoCredentials: vmConfig.NoCredentials,
 		CloudInitData: flags.Flags().Changed("cloudinit"),
+		BindMounts:    vmConfig.BindMounts,
 		RemoveVm:      vmConfig.RemoveVm,
 		Background:    vmConfig.Background,
 		SSHPort:       sshPort,

--- a/pkg/vm/domain-template.xml
+++ b/pkg/vm/domain-template.xml
@@ -35,6 +35,7 @@
       </backend>
     </tpm>
     {{.CloudInitCDRom}}
+    {{.Filesystems}}
   </devices>
   <qemu:commandline>
     <qemu:arg value='-netdev'/>

--- a/pkg/vm/domain-template.xml
+++ b/pkg/vm/domain-template.xml
@@ -17,6 +17,8 @@
     <type>hvm</type>
     <boot dev="hd"></boot>
   </os>
+  <!-- https://github.com/fedora-selinux/selinux-policy/issues/2124 -->
+  <seclabel type="none" model="selinux"/>
   <devices>
     <serial type="pty" />
     <disk device="disk" type="file">

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -62,6 +62,7 @@ type RunVMParameters struct {
 	Cmd           []string
 	RemoveVm      bool
 	Background    bool
+	BindMounts    []string
 }
 
 type BootcVM interface {
@@ -97,6 +98,7 @@ type BootcVMCommon struct {
 	hasCloudInit  bool
 	cloudInitDir  string
 	cloudInitArgs string
+	BindMounts    []string
 	bootcDisk     bootc.BootcDisk
 	cacheDirLock  utils.CacheLock
 }

--- a/pkg/vm/vm_darwin.go
+++ b/pkg/vm/vm_darwin.go
@@ -25,6 +25,10 @@ func NewVM(params NewVMParameters) (vm *BootcVMMac, err error) {
 		return nil, fmt.Errorf("image ID is required")
 	}
 
+	if len(params.BindMounts) > 0 {
+		return fmt.Errorf("bind mounts are currently not supported on this platform")
+	}
+
 	longId, cacheDir, err := GetVMCachePath(params.ImageID, params.User)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get VM cache path: %w", err)


### PR DESCRIPTION



This is extremely useful for local development cases, as
I can e.g. bind mount binaries I built on the host system.

Signed-off-by: Colin Walters <walters@verbum.org>