### PR TITLE
disk: Also pass stdin to install container

### DIFF
--- a/pkg/bootc/bootc_disk.go
+++ b/pkg/bootc/bootc_disk.go
@@ -342,7 +342,7 @@ func (p *BootcDisk) runInstallContainer(quiet bool, config DiskImageConfig) (err
 	var exitCode int32
 	if !quiet {
 		attachOpts := new(containers.AttachOptions).WithStream(true)
-		if err := containers.Attach(attachCancelCtx, p.bootcInstallContainerId, nil, os.Stdout, os.Stderr, nil, attachOpts); err != nil {
+		if err := containers.Attach(attachCancelCtx, p.bootcInstallContainerId, os.Stdin, os.Stdout, os.Stderr, nil, attachOpts); err != nil {
 			return fmt.Errorf("attaching: %w", err)
 		}
 	}


### PR DESCRIPTION
It's only by doing this that we end up calling into the code inside `attach()` that tries to ensure the terminal size matching. Otherwise we just get the default of 80 columns (and no dynamic SIGWINCH resizing).

This fixes the output in https://github.com/containers/bootc/pull/655