### PR TITLE
Macos switch to krunkit

### DIFF
--- a/cmd/vmmon.go
+++ b/cmd/vmmon.go
@@ -1,0 +1,68 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/containers/podman-bootc/pkg/user"
+	"github.com/containers/podman-bootc/pkg/vm"
+
+	"github.com/spf13/cobra"
+)
+
+// We treat this command as internal, we don't expect the user to call
+// this directly. In the future this will be replaced by an external binary
+var (
+	monCmd = &cobra.Command{
+		Use:    "vmmon <ID> <username> <ssh identity> <ssh port>",
+		Hidden: true,
+		Args:   cobra.ExactArgs(4),
+		RunE:   doMon,
+	}
+	console bool
+)
+
+func init() {
+	RootCmd.AddCommand(monCmd)
+	runCmd.Flags().BoolVar(&console, "console", false, "Show boot console")
+}
+
+func doMon(_ *cobra.Command, args []string) error {
+	usr, err := user.NewUser()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	fullImageId := args[0]
+	username := args[1]
+	sshIdentity := args[2]
+
+	sshPort, err := strconv.Atoi(args[3])
+	if err != nil {
+		return fmt.Errorf("invalid ssh port: %w", err)
+	}
+
+	cacheDir := filepath.Join(usr.CacheDir(), fullImageId)
+
+	// MacOS has a 104 bytes limit for a unix socket path
+	runDir := filepath.Join(usr.RunDir(), fullImageId[0:12])
+	if err := os.MkdirAll(runDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	params := vm.MonitorParmeters{
+		CacheDir:    cacheDir,
+		RunDir:      runDir,
+		Username:    username,
+		SshIdentity: sshIdentity,
+		SshPort:     sshPort,
+	}
+
+	return vm.StartMonitor(ctx, params)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,17 @@ go 1.20
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/containers/common v0.58.1
+	github.com/containers/gvisor-tap-vsock v0.7.3
 	github.com/containers/podman/v5 v5.0.1
 	github.com/docker/go-units v0.5.0
 	github.com/gofrs/flock v0.8.1
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
-	github.com/opencontainers/runtime-spec v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/sys v0.19.0
+	golang.org/x/term v0.19.0
 	libvirt.org/go/libvirt v1.10002.0
 )
 
@@ -40,7 +41,6 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/containers/buildah v1.35.3 // indirect
-	github.com/containers/gvisor-tap-vsock v0.7.3 // indirect
 	github.com/containers/image/v5 v5.30.0 // indirect
 	github.com/containers/libhvee v0.7.0 // indirect
 	github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 // indirect
@@ -134,6 +134,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.1.12 // indirect
+	github.com/opencontainers/runtime-spec v1.2.0 // indirect
 	github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/openshift/imagebuilder v1.2.6 // indirect
@@ -176,7 +177,6 @@ require (
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
-	golang.org/x/term v0.19.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 
 	"github.com/containers/podman-bootc/pkg/config"
@@ -57,6 +58,15 @@ func (u *User) DefaultIdentity() string {
 }
 
 func (u *User) RunDir() string {
+	if runtime.GOOS == "darwin" {
+		tmpDir, ok := os.LookupEnv("TMPDIR")
+		if !ok {
+			tmpDir = "/tmp"
+		}
+
+		return filepath.Join(tmpDir, config.ProjectName, "run")
+	}
+
 	return filepath.Join(xdg.RuntimeDir, config.ProjectName, "run")
 }
 

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -26,6 +26,15 @@ func ReadPidFile(pidFile string) (int, error) {
 	return int(pid), nil
 }
 
+func WritePidFile(pidFile string, pid int) error {
+	if pid < 1 {
+		// We might be running as PID 1 when running docker-in-docker,
+		// but 0 or negative PIDs are not acceptable.
+		return fmt.Errorf("invalid negative PID %d", pid)
+	}
+	return os.WriteFile(pidFile, []byte(strconv.Itoa(pid)), 0o644)
+}
+
 func FileExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	exists := false

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
+	"time"
 )
 
 func ReadPidFile(pidFile string) (int, error) {
@@ -34,4 +36,18 @@ func FileExists(path string) (bool, error) {
 		err = nil
 	}
 	return exists, err
+}
+
+// WaitForFileWithBackoffs attempts to discover a file in maxBackoffs attempts
+func WaitForFileWithBackoffs(maxBackoffs int, backoff time.Duration, path string) error {
+	backoffWait := backoff
+	for i := 0; i < maxBackoffs; i++ {
+		e, _ := FileExists(path)
+		if e {
+			return nil
+		}
+		time.Sleep(backoffWait)
+		backoffWait *= 2
+	}
+	return fmt.Errorf("unable to find file at %q", path)
 }

--- a/pkg/utils/process.go
+++ b/pkg/utils/process.go
@@ -14,3 +14,13 @@ func IsProcessAlive(pid int) bool {
 	err = process.Signal(syscall.Signal(0))
 	return err == nil
 }
+
+// SendInterrupt sends SIGINT to pid
+func SendInterrupt(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	return process.Signal(os.Interrupt)
+}

--- a/pkg/vm/gvproxy.go
+++ b/pkg/vm/gvproxy.go
@@ -1,0 +1,90 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/containers/podman-bootc/pkg/utils"
+
+	gvproxy "github.com/containers/gvisor-tap-vsock/pkg/types"
+	"github.com/sirupsen/logrus"
+)
+
+const gvproxyBinaryName = "gvproxy"
+
+type Vmm int
+
+const (
+	pidFileName = "gvproxy.pid"
+	socketFile  = "net.sock"
+	// How log we should wait for gvproxy to be ready
+	maxBackoffs = 5
+	backoff     = time.Millisecond * 200
+)
+
+type gvproxyParams struct {
+	SshPort int
+}
+
+type gvproxyDaemon struct {
+	socketPath string
+	pidFile    string
+	cmd        *exec.Cmd
+}
+
+func newGvproxy(ctx context.Context, binaryPath, rundir string, param gvproxyParams) *gvproxyDaemon {
+	socketPath := filepath.Join(rundir, socketFile)
+	pidFile := filepath.Join(rundir, pidFileName)
+
+	gvpCmd := gvproxy.NewGvproxyCommand()
+	gvpCmd.SSHPort = param.SshPort
+	gvpCmd.PidFile = pidFile
+	gvpCmd.AddVfkitSocket(fmt.Sprintf("unixgram://%s", socketPath))
+
+	cmdLine := gvpCmd.ToCmdline()
+	cmd := exec.CommandContext(ctx, binaryPath, cmdLine...)
+	logrus.Debugf("gvproxy command-line: %s %s", binaryPath, strings.Join(cmdLine, " "))
+
+	return &gvproxyDaemon{socketPath: socketPath, pidFile: pidFile, cmd: cmd}
+}
+
+// Start spawn the gvproxy daemon, killing any running daemon using the same unix socket file.
+// It blocks until the unix socket file exists, this does not guarantee that the socket will be
+// on listen state
+func (d *gvproxyDaemon) start() error {
+	cleanup(d.pidFile, d.socketPath)
+
+	if err := d.cmd.Start(); err != nil {
+		return fmt.Errorf("unable to start gvproxy: %w", err)
+	}
+
+	// this is racy, the socket file could exist but not be in the listen state yet
+	if err := utils.WaitForFileWithBackoffs(maxBackoffs, backoff, d.socketPath); err != nil {
+		return fmt.Errorf("waiting for gvproxy socket: %w", err)
+	}
+	return nil
+}
+
+func (d *gvproxyDaemon) stop() error {
+	return d.cmd.Cancel()
+}
+
+func (d *gvproxyDaemon) wait() error {
+	return d.cmd.Wait()
+}
+
+func cleanup(pidFile, socketPath string) {
+	// Let's kill any possible running daemon
+	pid, err := utils.ReadPidFile(pidFile)
+	if err == nil {
+		_ = utils.SendInterrupt(pid)
+	}
+
+	_ = os.Remove(pidFile)
+	_ = os.Remove(socketPath)
+}

--- a/pkg/vm/krunkit.go
+++ b/pkg/vm/krunkit.go
@@ -1,0 +1,110 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/containers/podman-bootc/pkg/utils"
+
+	"github.com/sirupsen/logrus"
+)
+
+const krunkitBinaryName = "krunkit"
+
+const defaultCpus = 4
+const defaultMemory = 2048
+
+type krunkitParams struct {
+	disk      string
+	netSocket string
+	oemString string
+	pidFile   string
+}
+
+type krunkit struct {
+	pidFile string
+	cmd     *exec.Cmd
+}
+
+func newKrunkit(ctx context.Context, binaryPath string, params krunkitParams) *krunkit {
+	cmdLine := newKrunkitCmdLine(defaultCpus, defaultMemory)
+	cmdLine.addRngDevice()
+	cmdLine.addBlockDevice(params.disk)
+	cmdLine.addNetworkDevice(params.netSocket)
+	cmdLine.addOemString(params.oemString)
+
+	cmdLineSlice := cmdLine.asSlice()
+	cmd := exec.CommandContext(ctx, binaryPath, cmdLineSlice...)
+	logrus.Debugf("krunkit command-line: %s %s", binaryPath, strings.Join(cmdLineSlice, " "))
+
+	return &krunkit{cmd: cmd, pidFile: params.pidFile}
+}
+
+func (k *krunkit) start() error {
+	if err := k.cmd.Start(); err != nil {
+		return fmt.Errorf("unable to start krunkit: %w", err)
+	}
+
+	if err := utils.WritePidFile(k.pidFile, k.cmd.Process.Pid); err != nil {
+		if err := k.cmd.Cancel(); err != nil {
+			logrus.Debugf("stopping krunkit: %v", err)
+		}
+		return fmt.Errorf("writing pid file %s: %w", k.pidFile, err)
+	}
+
+	return nil
+}
+
+func (k *krunkit) wait() error {
+	return k.cmd.Wait()
+}
+
+type krunkitCmdLine struct {
+	cpus      int
+	memory    int
+	devices   []string
+	oemString []string
+}
+
+func newKrunkitCmdLine(cpus int, memory int) *krunkitCmdLine {
+	return &krunkitCmdLine{cpus: cpus, memory: memory}
+}
+
+func (kc *krunkitCmdLine) addDevice(device string) {
+	kc.devices = append(kc.devices, device)
+}
+
+func (kc *krunkitCmdLine) addRngDevice() {
+	kc.addDevice("virtio-rng")
+}
+
+func (kc *krunkitCmdLine) addBlockDevice(diskAbsPath string) {
+	kc.addDevice(fmt.Sprintf("virtio-blk,path=%s", diskAbsPath))
+}
+
+func (kc *krunkitCmdLine) addNetworkDevice(socketAbsPath string) {
+	kc.addDevice(fmt.Sprintf("virtio-net,unixSocketPath=%s,mac=5a:94:ef:e4:0c:ee", socketAbsPath))
+}
+
+func (kc *krunkitCmdLine) addOemString(oemStr string) {
+	kc.oemString = append(kc.oemString, oemStr)
+}
+
+func (kc *krunkitCmdLine) asSlice() []string {
+	args := []string{}
+
+	args = append(args, "--cpus", strconv.Itoa(kc.cpus))
+	args = append(args, "--memory", strconv.Itoa(kc.memory))
+
+	for _, device := range kc.devices {
+		args = append(args, "--device", device)
+	}
+
+	for _, oemStr := range kc.oemString {
+		args = append(args, "--oem-string", oemStr)
+	}
+	return args
+}

--- a/pkg/vm/monitor.go
+++ b/pkg/vm/monitor.go
@@ -1,0 +1,117 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/containers/podman-bootc/pkg/config"
+
+	"github.com/sirupsen/logrus"
+)
+
+type stopFunction func() error
+type waitFunction func() error
+
+type MonitorParmeters struct {
+	CacheDir    string
+	RunDir      string
+	Username    string
+	SshIdentity string
+	SshPort     int
+}
+
+func StartMonitor(ctx context.Context, params MonitorParmeters) error {
+	netSocket, stopGvpd, err := startNetworkDaemon(ctx, params.RunDir, params.SshPort)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := stopGvpd(); err != nil {
+			logrus.Errorf("stoping gvproxy: %v", err)
+		}
+	}()
+
+	krkWait, err := startKrunkit(ctx, params.CacheDir, params.Username, params.SshIdentity, netSocket)
+	if err != nil {
+		return err
+	}
+
+	if err := krkWait(); err != nil {
+		logrus.Debugf("krunkit wait return error: %v", err)
+	}
+
+	return nil
+}
+
+func startNetworkDaemon(ctx context.Context, runDir string, sshPort int) (string, stopFunction, error) {
+	binaryPath, err := getBinaryPath(gvproxyBinaryName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	params := gvproxyParams{
+		SshPort: sshPort,
+	}
+
+	daemon := newGvproxy(ctx, binaryPath, runDir, params)
+
+	if err := daemon.start(); err != nil {
+		return "", nil, fmt.Errorf("could not start %s: %w", binaryPath, err)
+	}
+
+	// the only purpose of this gorutine is to capture the signal from the child process
+	go func(ctx context.Context, daemon *gvproxyDaemon) {
+		if err := daemon.wait(); err != nil {
+			logrus.Debugf("gvproxy wait return error: %v", err)
+		}
+	}(ctx, daemon)
+
+	return daemon.socketPath, daemon.stop, nil
+}
+
+func startKrunkit(ctx context.Context, cacheDir, username, sshIdentity, netSocketPath string) (waitFunction, error) {
+	binaryPath, err := getBinaryPath(krunkitBinaryName)
+	if err != nil {
+		return nil, err
+	}
+
+	pidFile := filepath.Join(cacheDir, config.RunPidFile)
+	disk := filepath.Join(cacheDir, config.DiskImage)
+
+	oemString, err := oemStringSystemdCredential(username, sshIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("creating oemstring systemd credential %w", err)
+	}
+
+	params := krunkitParams{
+		disk:      disk,
+		netSocket: netSocketPath,
+		oemString: oemString,
+		pidFile:   pidFile,
+	}
+
+	krk := newKrunkit(ctx, binaryPath, params)
+
+	err = krk.start()
+	if err != nil {
+		return nil, err
+	}
+
+	return krk.wait, nil
+}
+
+func getBinaryPath(binaryName string) (string, error) {
+	binaryPath, err := exec.LookPath(binaryName)
+	if err != nil {
+		return "", fmt.Errorf("could not find %s: %w", binaryName, err)
+	}
+
+	binaryPath, err = filepath.Abs(binaryPath)
+	if err != nil {
+		return "", fmt.Errorf("could not get absolut path of %s: %w", binaryPath, err)
+	}
+
+	return binaryPath, nil
+}

--- a/pkg/vm/oemstring.go
+++ b/pkg/vm/oemstring.go
@@ -1,0 +1,35 @@
+package vm
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func oemStringSystemdCredential(username, sshIdentity string) (string, error) {
+	tmpFilesCmd, err := tmpFileSshKey(username, sshIdentity)
+	if err != nil {
+		return "", err
+	}
+	oemString := fmt.Sprintf("io.systemd.credential.binary:tmpfiles.extra=%s", tmpFilesCmd)
+	return oemString, nil
+}
+
+func tmpFileSshKey(username, sshIdentity string) (string, error) {
+	pubKey, err := os.ReadFile(sshIdentity + ".pub")
+	if err != nil {
+		return "", err
+	}
+	pubKeyEnc := base64.StdEncoding.EncodeToString(pubKey)
+
+	userHomeDir := "/root"
+	if username != "root" {
+		userHomeDir = filepath.Join("/home", username)
+	}
+
+	tmpFileCmd := fmt.Sprintf("d %[1]s/.ssh 0750 %[2]s %[2]s -\nf+~ %[1]s/.ssh/authorized_keys 700 %[2]s %[2]s - %[3]s", userHomeDir, username, pubKeyEnc)
+
+	tmpFileCmdEnc := base64.StdEncoding.EncodeToString([]byte(tmpFileCmd))
+	return tmpFileCmdEnc, nil
+}

--- a/pkg/vm/vm_darwin.go
+++ b/pkg/vm/vm_darwin.go
@@ -1,13 +1,11 @@
 package vm
 
 import (
-	"errors"
 	"fmt"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
+	"strconv"
 
 	"github.com/containers/podman-bootc/pkg/config"
 	"github.com/containers/podman-bootc/pkg/utils"
@@ -56,31 +54,7 @@ func (b *BootcVMMac) CloseConnection() {
 }
 
 func (b *BootcVMMac) PrintConsole() (err error) {
-	//qemu seems to asynchronously create the socket file
-	//so this will wait up to a few seconds for socket to be created
-	socketCreationTimeout := 5 * time.Second
-	elapsed := 0 * time.Millisecond
-	interval := 100 * time.Millisecond
-	for elapsed < socketCreationTimeout {
-		time.Sleep(interval) //always sleep a little bit at the start
-		elapsed += interval
-		if _, err = os.Stat(b.socketFile); err == nil {
-			break
-		}
-	}
-
-	c, err := net.Dial("unix", b.socketFile)
-	if err != nil {
-		return fmt.Errorf("error connecting to socket %s", err)
-	}
-	for {
-		buf := make([]byte, 8192)
-		_, err := c.Read(buf)
-		if err != nil {
-			return fmt.Errorf("error reading socket %s", err)
-		}
-		print(string(buf))
-	}
+	return nil
 }
 
 func (b *BootcVMMac) GetConfig() (cfg *BootcVMConfig, err error) {
@@ -118,48 +92,24 @@ func (b *BootcVMMac) Run(params RunVMParameters) (err error) {
 		}
 	}
 
-	var args []string
-	args = append(args, "-display", "none")
-	args = append(args, "-chardev", fmt.Sprintf("socket,id=char0,server=on,wait=off,path=%s", b.socketFile), "-serial", "chardev:char0")
-
-	args = append(args, "-cpu", "host")
-	args = append(args, "-m", "2G")
-	args = append(args, "-smp", "2")
-	args = append(args, "-snapshot")
-	nicCmd := fmt.Sprintf("user,model=virtio-net-pci,hostfwd=tcp::%d-:22", b.sshPort)
-	args = append(args, "-nic", nicCmd)
-
-	vmPidFile := filepath.Join(b.cacheDir, "run.pid")
-	args = append(args, "-pidfile", vmPidFile)
-
-	vmDiskImage := filepath.Join(b.cacheDir, config.DiskImage)
-	driveCmd := fmt.Sprintf("if=virtio,format=raw,file=%s", vmDiskImage)
-	args = append(args, "-drive", driveCmd)
-
-	err = b.ParseCloudInit()
+	execPath, err := os.Executable()
 	if err != nil {
-		return err
+		return fmt.Errorf("getting executable path: %w", err)
 	}
 
-	if b.hasCloudInit {
-		args = append(args, "-cdrom", b.cloudInitArgs)
-	}
-
-	if b.sshIdentity != "" {
-		smbiosCmd, err := b.oemString()
-		if err != nil {
-			return err
-		}
-
-		args = append(args, "-smbios", smbiosCmd)
-	}
-
-	cmd, err := b.createQemuCommand()
+	execPath, err = filepath.EvalSymlinks(execPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("following executable symlink: %w", err)
 	}
 
-	cmd.Args = append(cmd.Args, args...)
+	execPath, err = filepath.Abs(execPath)
+	if err != nil {
+		return fmt.Errorf("getting executable absolute path: %w", err)
+	}
+
+	args := []string{"vmmon", b.imageID, b.vmUsername, b.sshIdentity, strconv.Itoa(b.sshPort)}
+	cmd := exec.Command(execPath, args...)
+
 	logrus.Debugf("Executing: %v", cmd.Args)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -212,37 +162,6 @@ func (b *BootcVMMac) IsRunning() (bool, error) {
 
 func (b *BootcVMMac) Exists() (bool, error) {
 	return utils.FileExists(b.pidFile)
-}
-
-func (b *BootcVMMac) createQemuCommand() (*exec.Cmd, error) {
-	qemuInstallPath, err := getQemuInstallPath()
-	if err != nil {
-		return nil, err
-	}
-
-	path := qemuInstallPath + "/bin/qemu-system-aarch64"
-	args := []string{
-		"-accel", "hvf",
-		"-cpu", "host",
-		"-M", "virt,highmem=on",
-		"-drive", "file=" + qemuInstallPath + "/share/qemu/edk2-aarch64-code.fd" + ",if=pflash,format=raw,readonly=on",
-	}
-	return exec.Command(path, args...), nil
-}
-
-// Search for a qemu binary, let's check if is shipped with podman v4
-// or if it's installed using homebrew.
-// This function will no longer be necessary as soon as we use libvirt on macos.
-func getQemuInstallPath() (string, error) {
-	dirs := []string{"/opt/homebrew", "/opt/podman/qemu"}
-	for _, d := range dirs {
-		qemuBinary := filepath.Join(d, "bin/qemu-system-aarch64")
-		if _, err := os.Stat(qemuBinary); err == nil {
-			return d, nil
-		}
-	}
-
-	return "", errors.New("QEMU binary not found")
 }
 
 func (v *BootcVMMac) Unlock() error {


### PR DESCRIPTION
 
In order to switch from QEMU to krunkit we need to use gvproxy   to provide network support to the VM. We need to bound gvproxy     lifetime to krunkit lifetime, so there is not an "orphan"     daemon after krunkit finish.
    
We are using an "internal" command to monitor, in the future     this should be a different binary, but right now is the     easiest way. We save the pid of krunkit instead of the monitor    because the `stop` command sends a SIGINT to that pid, and    we currently are capturing the signal at podman-bootc.
