### PR TITLE
Inject RSA ssh key

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,7 +19,6 @@ type osVmConfig struct {
 	CloudInitDir    string
 	KsFile          string
 	Background      bool
-	NoCredentials   bool
 	RemoveVm        bool // Kill the running VM when it exits
 	RemoveDiskImage bool // After exit of the VM, remove the disk image
 	Quiet           bool
@@ -47,7 +46,6 @@ func init() {
 	runCmd.Flags().StringVar(&vmConfig.CloudInitDir, "cloudinit", "", "--cloudinit <cloud-init data directory>")
 
 	runCmd.Flags().StringVar(&diskImageConfigInstance.Filesystem, "filesystem", "", "Override the root filesystem (e.g. xfs, btrfs, ext4)")
-	runCmd.Flags().BoolVar(&vmConfig.NoCredentials, "no-creds", false, "Do not inject default SSH key via credentials; also implies --background")
 	runCmd.Flags().BoolVarP(&vmConfig.Background, "background", "B", false, "Do not spawn SSH, run in background")
 	runCmd.Flags().BoolVar(&vmConfig.RemoveVm, "rm", false, "Remove the VM and it's disk when the SSH session exits. Cannot be used with --background")
 	runCmd.Flags().BoolVar(&vmConfig.Quiet, "quiet", false, "Suppress output from bootc disk creation and VM boot console")
@@ -108,7 +106,6 @@ func doRun(flags *cobra.Command, args []string) error {
 	err = bootcVM.Run(vm.RunVMParameters{
 		Cmd:           cmd,
 		CloudInitDir:  vmConfig.CloudInitDir,
-		NoCredentials: vmConfig.NoCredentials,
 		CloudInitData: flags.Flags().Changed("cloudinit"),
 		RemoveVm:      vmConfig.RemoveVm,
 		Background:    vmConfig.Background,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/containers/podman-bootc/pkg/bootc"
 	"github.com/containers/podman-bootc/pkg/config"
+	"github.com/containers/podman-bootc/pkg/credentials"
 	"github.com/containers/podman-bootc/pkg/user"
 	"github.com/containers/podman-bootc/pkg/utils"
 	"github.com/containers/podman-bootc/pkg/vm"
@@ -102,6 +103,11 @@ func doRun(flags *cobra.Command, args []string) error {
 		}
 	}()
 
+	sSHIdentityPath, err := credentials.Generatekeys(bootcVM.CacheDir())
+	if err != nil {
+		return fmt.Errorf("unable to generate ssh key: %w", err)
+	}
+
 	cmd := args[1:]
 	err = bootcVM.Run(vm.RunVMParameters{
 		Cmd:           cmd,
@@ -110,7 +116,7 @@ func doRun(flags *cobra.Command, args []string) error {
 		RemoveVm:      vmConfig.RemoveVm,
 		Background:    vmConfig.Background,
 		SSHPort:       sshPort,
-		SSHIdentity:   machine.SSHIdentityPath,
+		SSHIdentity:   sSHIdentityPath,
 		VMUser:        vmConfig.User,
 	})
 

--- a/pkg/credentials/ssh.go
+++ b/pkg/credentials/ssh.go
@@ -10,13 +10,14 @@ import (
 	"github.com/containers/podman-bootc/pkg/config"
 )
 
-// Generatekeys creates an ed25519 set of keys
+// Generatekeys creates an RSA set of keys
 func Generatekeys(outputDir string) (string, error) {
 	sshIdentity := filepath.Join(outputDir, config.SshKeyFile)
 	_ = os.Remove(sshIdentity)
 	_ = os.Remove(sshIdentity + ".pub")
 
-	args := []string{"-N", "", "-t", "ed25519", "-f", sshIdentity}
+	// we use RSA here so it works on FIPS mode
+	args := []string{"-N", "", "-t", "rsa", "-f", sshIdentity}
 	cmd := exec.Command("ssh-keygen", args...)
 	stdErr, err := cmd.StderrPipe()
 	if err != nil {

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -54,7 +54,6 @@ type NewVMParameters struct {
 type RunVMParameters struct {
 	VMUser        string //user to use when connecting to the VM
 	CloudInitDir  string
-	NoCredentials bool
 	CloudInitData bool
 	SSHIdentity   string
 	SSHPort       int

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -70,6 +70,7 @@ type BootcVM interface {
 	WaitForSSHToBeReady() error
 	RunSSH([]string) error
 	DeleteFromCache() error
+	CacheDir() string
 	Exists() (bool, error)
 	GetConfig() (*BootcVMConfig, error)
 	CloseConnection()
@@ -250,6 +251,10 @@ func (v *BootcVMCommon) RunSSH(inputArgs []string) error {
 // Delete removes the VM disk image and the VM configuration from the podman-bootc cache
 func (v *BootcVMCommon) DeleteFromCache() error {
 	return os.RemoveAll(v.cacheDir)
+}
+
+func (v *BootcVMCommon) CacheDir() string {
+	return v.cacheDir
 }
 
 func (b *BootcVMCommon) oemString() (string, error) {

--- a/pkg/vm/vm_darwin.go
+++ b/pkg/vm/vm_darwin.go
@@ -84,14 +84,6 @@ func (b *BootcVMMac) Run(params RunVMParameters) (err error) {
 	b.vmUsername = params.VMUser
 	b.sshIdentity = params.SSHIdentity
 
-	if params.NoCredentials {
-		b.sshIdentity = ""
-		if !b.background {
-			fmt.Print("No credentials provided for SSH, using --background by default")
-			b.background = true
-		}
-	}
-
 	execPath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("getting executable path: %w", err)

--- a/pkg/vm/vm_linux.go
+++ b/pkg/vm/vm_linux.go
@@ -123,14 +123,6 @@ func (v *BootcVMLinux) Run(params RunVMParameters) (err error) {
 	v.vmUsername = params.VMUser
 	v.sshIdentity = params.SSHIdentity
 
-	if params.NoCredentials {
-		v.sshIdentity = ""
-		if !v.background {
-			fmt.Print("No credentials provided for SSH, using --background by default")
-			v.background = true
-		}
-	}
-
 	if v.domain != nil {
 		isRunning, err := v.IsRunning()
 		if err != nil {

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -96,7 +96,6 @@ func runTestVM(bootcVM vm.BootcVM) {
 	err := bootcVM.Run(vm.RunVMParameters{
 		VMUser:        "root",
 		CloudInitDir:  "",
-		NoCredentials: false,
 		CloudInitData: false,
 		SSHPort:       22,
 		Cmd:           []string{},


### PR DESCRIPTION
For simplicity, we were using the ssh key from podman-machine, but it has the inconvenience that this key is ed25519 and does not work in FIPS mode.

Let's generate and inject an RSA ssh key that it's FIPS approved.

This PR also removes `--no-creds` because it was broken, making the `run` and `ssh` command to fail. Since no-one complained we can safely remove it to avoid confuse the user. We can bring it back if someone ask for that functionality in the future.

Fixes #68 