### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/podman-bootc-run.1.md
+++ b/docs/podman-bootc-run.1.md
@@ -36,7 +36,7 @@ Log messages at and above specified level: __debug__, __info__, __warn__, __erro
 Suppress output from bootc disk creation and VM boot console
 
 #### **--rm**
-Remove the VM and it's disk image when the SSH connection exits. Cannot be used with *--background*
+Remove the VM and its disk image when the SSH connection exits. Cannot be used with *--background*
 
 #### **--root-size-max**=**string**
 Maximum size of root filesystem in bytes; optionally accepts M, G, T suffixes


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct ‘it's’ to ‘its’ in the --rm option description of the podman-bootc-run documentation